### PR TITLE
feat: Search페이지 구현 및 PokemonCard 컴포넌트 분리(#20)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,10 @@
         "@reduxjs/toolkit": "^2.7.0",
         "@tailwindcss/vite": "^4.1.4",
         "clsx": "^2.1.1",
+        "korean-regexp": "^1.0.13",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-icons": "^5.5.0",
         "react-redux": "^9.2.0",
         "react-router": "^7.5.2",
         "tailwindcss": "^4.1.4"
@@ -4120,6 +4122,12 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/korean-regexp": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/korean-regexp/-/korean-regexp-1.0.13.tgz",
+      "integrity": "sha512-U+dULDtJSZnzbV13hg2EjTaoKqXRqucDArmzb/3KX+DyP1lAzEXoTvTK992m7cmOTAJ2xrv4RueXlMBKdhJ1bQ==",
+      "license": "MIT"
+    },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
@@ -4964,6 +4972,15 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
     "@reduxjs/toolkit": "^2.7.0",
     "@tailwindcss/vite": "^4.1.4",
     "clsx": "^2.1.1",
+    "korean-regexp": "^1.0.13",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-icons": "^5.5.0",
     "react-redux": "^9.2.0",
     "react-router": "^7.5.2",
     "tailwindcss": "^4.1.4"

--- a/src/components/AllCards.tsx
+++ b/src/components/AllCards.tsx
@@ -1,0 +1,13 @@
+import PokemonCardContainer from "@components/PokemonCardContainer";
+import { useAppSelector } from "@app/hooks";
+
+const AllCards = () => {
+  const pokemonData = useAppSelector((state) => state.pokemon);
+
+  if (pokemonData.loading) {
+    return <div>로딩중</div>;
+  }
+
+  return <PokemonCardContainer pokemonData={pokemonData.data} />;
+};
+export default AllCards;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,10 +1,22 @@
+import { useNavigate, Link } from "react-router";
 import { NAVIGATION_URL } from "@constants/url";
-import { Link } from "react-router";
+import { IoIosSearch } from "react-icons/io";
 
 const Header = () => {
+  const navigate = useNavigate();
+
   return (
-    <header className="mx-auto flex max-w-7xl items-center justify-between p-4">
-      <div className="text-xl font-bold">포켓몬 도감</div>
+    <header className="mx-auto flex max-w-7xl items-center justify-between gap-6 p-6">
+      <div className="mr-auto text-xl font-bold">포켓몬 도감</div>
+      <div className="flex items-center gap-2">
+        <IoIosSearch size={20} />
+        <input
+          className="w-62 border-b-2 border-gray-400 focus:border-blue-400 focus:outline-none"
+          onChange={(e) => navigate(`/search?pokemon=${e.target.value}`)}
+          placeholder="검색어를 입력해주세요"
+          type="text"
+        />
+      </div>
       <nav className="flex gap-8 font-normal">
         {NAVIGATION_URL.map(({ name, url }) => (
           <Link key={url} to={url}>

--- a/src/components/PokemonCardContainer.tsx
+++ b/src/components/PokemonCardContainer.tsx
@@ -1,16 +1,14 @@
 import PokemonCard from "@components/PokemonCard";
-import { useAppSelector } from "@app/hooks";
+import { PokeData } from "@src/types/types";
 
-const PokemonCardContainer = () => {
-  const pokemonData = useAppSelector((state) => state.pokemon);
+interface PokemonCardContainerProps {
+  pokemonData: PokeData[];
+}
 
-  if (pokemonData.loading) {
-    return <div>로딩중</div>;
-  }
-
+const PokemonCardContainer = ({ pokemonData }: PokemonCardContainerProps) => {
   return (
     <section className="mx-auto grid w-fit grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-7">
-      {pokemonData.data.map((pokemon) => (
+      {pokemonData.map((pokemon) => (
         <PokemonCard key={pokemon.id} {...pokemon} />
       ))}
     </section>

--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -2,5 +2,4 @@ export const NAVIGATION_URL = [
   { name: "메인", url: "/" },
   { url: "/detail", name: "상세정보" },
   { url: "/favorites", name: "찜목록" },
-  { url: "/search", name: "검색" },
 ];

--- a/src/features/pokemon/pokeSlice.ts
+++ b/src/features/pokemon/pokeSlice.ts
@@ -1,6 +1,6 @@
 import { createSelector, createSlice } from "@reduxjs/toolkit";
-import { PokeData } from "@/types/types";
-import { RootState } from "@/app/store";
+import { PokeData } from "@src/types/types";
+import { RootState } from "@app/store";
 
 import { fetchMultiplePokemonById } from "./pokeThunk";
 
@@ -33,6 +33,13 @@ export const selectPokemonById = (pokemonId: number) =>
   createSelector(
     (state: RootState) => state.pokemon.data,
     (pokemon) => pokemon.find((element: PokeData) => element.id === pokemonId),
+  );
+
+export const selectPokemonByRegexp = (pokemonReg: RegExp) =>
+  createSelector(
+    (state: RootState) => state.pokemon.data,
+    (pokemon) =>
+      pokemon.filter((element: PokeData) => element.name.match(pokemonReg)),
   );
 
 export default pokeSlice.reducer;

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,9 +1,9 @@
-import PokemonCardContainer from "@components/PokemonCardContainer";
+import AllCards from "@components/AllCards";
 
 const Main = () => {
   return (
     <>
-      <PokemonCardContainer />
+      <AllCards />
     </>
   );
 };

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -1,4 +1,15 @@
+import { selectPokemonByRegexp } from "@features/pokemon/pokeSlice";
+import PokemonCardContainer from "@components/PokemonCardContainer";
+import { useSearchParams } from "react-router";
+import { useAppSelector } from "@app/hooks";
+import { getRegExp } from "korean-regexp";
+
 const Search = () => {
-  return <div>Search</div>;
+  const [searchParams] = useSearchParams();
+  const param = searchParams.get("pokemon") ?? "";
+  const reg = getRegExp(param);
+  const pokemonData = useAppSelector(selectPokemonByRegexp(reg));
+
+  return <PokemonCardContainer pokemonData={pokemonData} />;
 };
 export default Search;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #20

## 📝작업 내용

> Search페이지 구현
- Header에 검색창 추가
- url 파라미터에 따라 search페이지에 검색결과 표시
- 검색어를 Redux 상태와 연동하여 필터링된 포켓몬 리스트 표시
- korean-regexp 라이브러리를 사용하여 필터링
- react-icons 설치
- PokemonCardContainer 수정, 메인 페이지에서 사용할 컴포넌트를 따로 분리


