### PR TITLE
feat: 찜하기 기능 구현(#22)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,6 +20,7 @@ export default tseslint.config(
         "warn",
         { allowConstantExport: true },
       ],
+      "jsx-a11y/click-events-have-key-events": "off",
       "react/button-has-type": "error",
     },
     plugins: {

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,8 +1,10 @@
+import favoriteReducer from "@features/favorite/favoriteSlice";
 import pokeReducer from "@features/pokemon/pokeSlice";
 import { configureStore } from "@reduxjs/toolkit";
 
 export const store = configureStore({
   reducer: {
+    favorite: favoriteReducer,
     pokemon: pokeReducer,
   },
 });

--- a/src/components/FavoriteButton.tsx
+++ b/src/components/FavoriteButton.tsx
@@ -1,0 +1,33 @@
+import { favoriteSlice } from "@features/favorite/favoriteSlice";
+import { useAppDispatch, useAppSelector } from "@app/hooks";
+import { IoMdHeartEmpty, IoMdHeart } from "react-icons/io";
+
+interface FavoriteButtonProps {
+  pokemonId: number;
+}
+
+const FavoriteButton = ({ pokemonId }: FavoriteButtonProps) => {
+  const isFavorite = useAppSelector((state) =>
+    state.favorite.some((item) => item === pokemonId),
+  );
+
+  const dispatch = useAppDispatch();
+
+  return (
+    <button
+      onClick={(e) => {
+        e.stopPropagation();
+        dispatch(
+          isFavorite
+            ? favoriteSlice.actions.removeFromFavorite(pokemonId)
+            : favoriteSlice.actions.addToFavorite(pokemonId),
+        );
+      }}
+      type="button"
+    >
+      {isFavorite ? <IoMdHeart /> : <IoMdHeartEmpty />}
+    </button>
+  );
+};
+
+export default FavoriteButton;

--- a/src/components/PokemonCard.tsx
+++ b/src/components/PokemonCard.tsx
@@ -1,3 +1,4 @@
+import FavoriteButton from "@components/FavoriteButton";
 import { PokeData } from "@src/types/types";
 import { useNavigate } from "react-router";
 
@@ -5,17 +6,19 @@ const PokemonCard = ({ front, name, back, id }: PokeData) => {
   const navigate = useNavigate();
 
   return (
-    <button
+    <div
       className="flex w-[160px] flex-col items-center justify-center rounded-lg border-2 border-gray-200 p-4"
       onClick={() => navigate(`/detail/${id}`)}
-      type="button"
+      role="button"
+      tabIndex={0}
     >
+      <FavoriteButton pokemonId={id} />
       <div>
         <img src={front} alt={name} />
         <img className="hidden" src={back} alt={name} />
       </div>
       <div>{name}</div>
-    </button>
+    </div>
   );
 };
 export default PokemonCard;

--- a/src/features/favorite/favoriteSlice.ts
+++ b/src/features/favorite/favoriteSlice.ts
@@ -1,0 +1,17 @@
+import { PayloadAction, createSlice } from "@reduxjs/toolkit";
+
+export const favoriteSlice = createSlice({
+  reducers: {
+    removeFromFavorite(state, action: PayloadAction<number>) {
+      const index = state.indexOf(action.payload);
+      if (index !== -1) state.splice(index, 1);
+    },
+    addToFavorite(state, action: PayloadAction<number>) {
+      state.push(action.payload);
+    },
+  },
+  initialState: [] as number[],
+  name: "favorite",
+});
+
+export default favoriteSlice.reducer;

--- a/src/features/pokemon/pokeSlice.ts
+++ b/src/features/pokemon/pokeSlice.ts
@@ -42,4 +42,12 @@ export const selectPokemonByRegexp = (pokemonReg: RegExp) =>
       pokemon.filter((element: PokeData) => element.name.match(pokemonReg)),
   );
 
+export const selectFavoritePokemon = createSelector(
+  (state: RootState) => state.pokemon.data,
+  (state: RootState) => state.favorite,
+  (pokemon, favorite) => {
+    return pokemon.filter((element) => favorite.includes(element.id));
+  },
+);
+
 export default pokeSlice.reducer;

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -1,7 +1,8 @@
 import { selectPokemonById } from "@features/pokemon/pokeSlice";
+import FavoriteButton from "@components/FavoriteButton";
 import { useAppSelector } from "@app/hooks";
+import { PokeData } from "@src/types/types";
 import { useParams } from "react-router";
-import { PokeData } from "@/types/types";
 
 const Detail = () => {
   const { pokemonId } = useParams();
@@ -14,9 +15,11 @@ const Detail = () => {
   }
 
   return (
-    <div className="mx-auto flex w-fit flex-col items-center justify-center rounded-2xl border-2 border-gray-200 p-4">
-      <div className="text-2xl">{pokemon.name}</div>
-      <div className="text-center whitespace-pre-wrap">
+    <div className="mx-auto flex w-fit flex-col items-center justify-center gap-4 rounded-2xl border-2 border-gray-200 p-4">
+      <div className="flex w-full items-center justify-between text-2xl">
+        {pokemon.name} <FavoriteButton pokemonId={Number(pokemonId)} />
+      </div>
+      <div className="w-full text-left whitespace-pre-wrap">
         <div>{pokemon.description}</div>
       </div>
       <img

--- a/src/pages/Favorites.tsx
+++ b/src/pages/Favorites.tsx
@@ -1,4 +1,10 @@
+import PokemonCardContainer from "@components/PokemonCardContainer";
+import { selectFavoritePokemon } from "@features/pokemon/pokeSlice";
+import { useAppSelector } from "@app/hooks";
+
 const Favorites = () => {
-  return <div>Favorites</div>;
+  const favorites = useAppSelector(selectFavoritePokemon);
+
+  return <PokemonCardContainer pokemonData={favorites} />;
 };
 export default Favorites;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #22

## 📝작업 내용

> 찜하기 기능 구현
- favoriteSlice 구현
- selectFavoritePokemon selector 구현
- FavoriteButton 구현
- Favorite 페이지 구현
- jsx-a11y/click-events-have-key-events 규칙 끄기
- PokemonCard 컴포넌트를 div로 변경
- Detail 페이지 정렬 수정, PokeData 타입 경로 수정

