### PR TITLE
design: 디자인 수정(#28)

### DIFF
--- a/src/components/FavoriteButton.tsx
+++ b/src/components/FavoriteButton.tsx
@@ -25,7 +25,7 @@ const FavoriteButton = ({ pokemonId }: FavoriteButtonProps) => {
       }}
       type="button"
     >
-      {isFavorite ? <IoMdHeart /> : <IoMdHeartEmpty />}
+      {isFavorite ? <IoMdHeart fill="#e53e3e" /> : <IoMdHeartEmpty />}
     </button>
   );
 };

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,7 +7,9 @@ const Header = () => {
   return (
     <header className="mx-auto flex max-w-7xl items-center justify-between gap-6 p-6">
       <Link to={"/"}>
-        <div className="mr-auto text-xl font-bold">포켓몬 도감</div>
+        <div className="mr-auto font-[NeoDunggeunmo] text-xl font-bold">
+          포켓몬 도감
+        </div>
       </Link>
       <div className="flex items-center gap-6">
         <div className="flex items-center gap-2">

--- a/src/components/PokemonCard.tsx
+++ b/src/components/PokemonCard.tsx
@@ -7,7 +7,7 @@ const PokemonCard = ({ front, name, back, id }: PokeData) => {
 
   return (
     <div
-      className="flex w-[160px] flex-col items-center justify-center rounded-lg border-2 border-gray-200 p-4"
+      className="flex w-[160px] flex-col items-center justify-center rounded-lg border-2 border-gray-200 p-4 shadow-md duration-100 hover:scale-110 hover:border-r-red-600 hover:border-b-red-600"
       onClick={() => navigate(`/detail/${id}`)}
       role="button"
       tabIndex={0}
@@ -17,7 +17,7 @@ const PokemonCard = ({ front, name, back, id }: PokeData) => {
         <img src={front} alt={name} />
         <img className="hidden" src={back} alt={name} />
       </div>
-      <div>{name}</div>
+      <div className="font-[NeoDunggeunmo]">{name}</div>
     </div>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,14 @@
 @import "tailwindcss";
 
 @font-face {
+  font-family: "NeoDunggeunmo";
+  src: url("https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2001@1.3/NeoDunggeunmo.woff")
+    format("woff");
+  font-weight: normal;
+  font-style: normal;
+}
+
+@font-face {
   font-family: "Pretendard Variable";
   font-weight: 45 920;
   font-style: normal;

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -44,7 +44,7 @@ const Detail = () => {
 
   return (
     <div className="mx-auto flex w-fit flex-col items-center justify-center gap-4 rounded-2xl border-2 border-gray-200 p-4 transform-3d">
-      <div className="flex w-full items-center justify-between text-2xl">
+      <div className="flex w-full items-center justify-between font-[NeoDunggeunmo] text-2xl">
         {pokemon.name} <FavoriteButton pokemonId={Number(pokemonId)} />
       </div>
       <div className="w-full text-left whitespace-pre-wrap">


### PR DESCRIPTION
## #️⃣연관된 이슈

> #28

## 📝작업 내용

> 디자인 수정
- PokemonCard에 그림자 적용
- PokemonCard 마우스 올라갔을 때 커지고, 오른쪽 아래 border 색상 변경
- 로고, 포켓몬 이름 폰트 변경
- 좋아요 버튼 선택됐을 때 색상 변경

